### PR TITLE
Add back browserify build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist/shacl.js

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,4 @@
 var gulp = require('gulp');
-var browserify = require('gulp-browserify');
 var fs = require('fs');
 
 var http = require("https");
@@ -58,23 +57,6 @@ gulp.task('checkJavaFiles', function (cb) {
     checkFiles(files);
 });
 
-gulp.task('browserify', function () {
-    if (fs.existsSync('dist/index.js')) {
-        fs.unlinkSync('dist/index.js');
-    }
-    if (fs.existsSync('dist/shacl.js')) {
-        fs.unlinkSync('dist/shacl.js');
-    }
-    gulp.src('index.js')
-        .pipe(browserify({
-            standalone: 'SHACLValidator'
-        }))
-        .pipe(gulp.dest('dist'))
-        .on('end', function () {
-            fs.renameSync('dist/index.js', 'dist/shacl.js');
-        });
-});
-
 
 gulp.task('generate-vocabularies', function () {
     var vocabularies = fs.readdirSync("./vocabularies");
@@ -109,4 +91,3 @@ gulp.task('generate-libraries', function () {
     fs.writeFileSync("./src/rdfquery.js", generated);
 });
 
-gulp.task('default', ['browserify']);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "SHACL.JS Validator",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "browserify": "browserify index.js --standalone SHACLValidator > dist/shacl.js"
   },
   "author": "Holger Knublauch <holger@topquadrant.com>",
   "license": "Apache-2.0",
@@ -15,9 +16,9 @@
     "string-to-stream": "3.0.1"
   },
   "devDependencies": {
+    "browserify": "^16.5.0",
     "debug": "4.1.1",
     "gulp": "^3.9.1",
-    "gulp-browserify": "^0.5.1",
     "gulp-cli": "^1.4.0",
     "gulp-serve": "^1.4.0",
     "http-browserify": "^1.7.0",


### PR DESCRIPTION
This removes the broken and deprecated gulp-browserify and instead builds with browserify directly.